### PR TITLE
Scaling of ice caps with proper parameters

### DIFF
--- a/oggm_vas/core.py
+++ b/oggm_vas/core.py
@@ -55,15 +55,23 @@ def initialize(**kwargs):
 
     # area-volume scaling parameters for glaciers (cp. Marzeion et. al., 2012)
     # units: m^(3-2*gamma) and unitless, respectively
-    cfg.PARAMS['vas_c_area_m2'] = 0.191
+    cfg.PARAMS['vas_c_area_m2'] = 0.1912
     cfg.PARAMS['vas_gamma_area'] = 1.375
 
     # area-length scaling parameters for glaciers (cp. Marzeion et. al., 2012)
     # units: m^(3-q) and unitless, respectively
-    cfg.PARAMS['vas_c_length_m'] = 4.5507
+    cfg.PARAMS['vas_c_length_m'] = 4.5214
     cfg.PARAMS['vas_q_length'] = 2.2
 
-    # TODO: include scaling parameters for ice caps?!
+    # area-volume scaling parameters for glaciers (cp. Marzeion et. al., 2012)
+    # units: m^(3-2*gamma) and unitless, respectively
+    cfg.PARAMS['vas_c_icecap_area_m2'] = 1.7013
+    cfg.PARAMS['vas_gamma_icecap_area'] = 1.25
+
+    # area-length scaling parameters for glaciers (cp. Marzeion et. al., 2012)
+    # units: m^(3-q) and unitless, respectively
+    cfg.PARAMS['vas_c_icecap_length_m'] = 7.1214
+    cfg.PARAMS['vas_q_icecap_length'] = 2.5
 
 
 def get_ref_tstars_filepath(fname):


### PR DESCRIPTION
The scaling parameters (scaling constant and scaling exponent) for ice caps are different than those for glaciers, see e.g. [Marzeion et al. 2012](https://tc.copernicus.org/articles/6/1295/2012/). The `VAScalingModel` now has a `glacier_type` property, so that the correct parameters can be used. The glacier type has to be specified if a `VAScalingModel` object is instantiated. Wherever possibly, the glacier type is directly inferred from the glacier directory.

Closes #10.

Test are not updated yet...